### PR TITLE
Adjust to new esphome platform definition

### DIFF
--- a/Wemos 1.2
+++ b/Wemos 1.2
@@ -1,6 +1,7 @@
 esphome:
   name: mvtestgroen
-  platform: ESP8266
+
+esp8266:
   board: d1_mini_pro
 
 wifi:

--- a/Wemos 1.3
+++ b/Wemos 1.3
@@ -1,6 +1,7 @@
 esphome:
   name: mvtest13
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 wifi:


### PR DESCRIPTION
Notices esphome refused the existing config, this change makes it compatible again.